### PR TITLE
add support for building instant-gnuradio via packer on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/assets/.gitattributes
+++ b/assets/.gitattributes
@@ -1,0 +1,10 @@
+*.rules text eol=lf
+*.conf text eol=lf
+*.desktop text eol=lf
+*.cfg text eol=lf
+spacemacs text eol=lf
+terminator text eol=lf
+vimrc text eol=lf
+zenburn.vim text eol=lf
+zshenv text eol=lf
+zshrc text eol=lf

--- a/grub2/.gitattributes
+++ b/grub2/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/scripts/.gitattributes
+++ b/scripts/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
without these .gitattributes the assets/ , scripts/ etc. files get ^M inserted on checkout and this makes the VM angry later on :)