### PR TITLE
attempt to fix some intermittent build failures

### DIFF
--- a/scripts/init-base.sh
+++ b/scripts/init-base.sh
@@ -14,6 +14,11 @@ done
 echo "==> Updating list of repositories"
 sudo apt-get -y update
 
+echo "==> adding apt-smart from pip and updating apt mirror"
+sudo apt-get -y install python3-pip
+sudo pip3 install apt-smart
+sudo apt-smart --auto-change-mirror
+
 echo "==> Upgrading Packages"
 sudo apt-get upgrade --fix-missing -y
 

--- a/scripts/init-base.sh
+++ b/scripts/init-base.sh
@@ -2,11 +2,20 @@
 
 set -exu
 
+while (sudo fuser /var/lib/apt/lists/lock) >/dev/null 2>&1 ; do
+	echo "Another package manager is currently using apt/lists. Waiting..."
+	sleep 1s
+done
+while (sudo fuser /var/lib/dpkg/lock) >/dev/null 2>&1 ; do
+	echo "Another package manager is currently using dpkg. Waiting..."
+	sleep 1s
+done
+
 echo "==> Updating list of repositories"
 sudo apt-get -y update
 
 echo "==> Upgrading Packages"
-sudo apt-get -y upgrade
+sudo apt-get upgrade --fix-missing -y
 
 echo "==> Installing ubuntu-gnome-desktop"
 sudo apt-get install -y network-manager


### PR DESCRIPTION
The other build failures I've experienced lately are
* dpkg lock held . I'm assuming it is by cloud-init which isn't quite done when init-base.sh runs
* hash sum mismatches. I'm assuming it is because of overload of the default apt mirror

question to you @bastibl : would you be ok with headless=true in base.json? it is the way I run all the builds here (with uncomitted changes)