### PR TITLE
Enable nat-localhostreachable to support VirtualBox 7.0+

### DIFF
--- a/base.json
+++ b/base.json
@@ -37,7 +37,8 @@
             ["modifyvm", "{{.Name}}", "--clipboard", "bidirectional"],
             ["modifyvm", "{{.Name}}", "--audioout", "on"],
             ["modifyvm", "{{.Name}}", "--audioin", "on"],
-            ["modifyvm", "{{.Name}}", "--graphicscontroller", "vmsvga"]
+            ["modifyvm", "{{.Name}}", "--graphicscontroller", "vmsvga"],
+            ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"]
         ]
     }],
     "provisioners": [


### PR DESCRIPTION
Without this change, the build hangs when trying to establish the first SSH connection.

I found this workaround mentioned in https://github.com/hashicorp/packer/issues/12118 and https://github.com/hashicorp/packer-plugin-virtualbox/issues/104.

Note: This works for me on VirtualBox 7.0.10, but I did NOT test whether this change breaks previous versions.